### PR TITLE
Restrict push to test pypi CI action to organizational repository

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -23,6 +23,7 @@ jobs:
     name: publish to test pypi
     needs: build
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'mammothbio-os/palamedes' }}
 
     environment:
       name: test-release


### PR DESCRIPTION
## Description
<!-- please add a summary for this PR. Remember this summary should "scale" with the size of the PR!  -->
Restrict push to test pypi CI action to organizational repository.  Fixes #9.

I don't know of a good way to test this other than merging and then syncing my fork.
