### PR TITLE
Push to pypi

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.1
+current_version = 0.0.2
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 0.0.1
 commit = True
-tag = True
+tag = False
 
 [bumpversion:file:setup.py]
 

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -18,28 +18,3 @@ jobs:
   build:
     needs: [test, lint, docs]
     uses: ./.github/workflows/build.yaml
-
-  test-release:
-    name: publish to test pypi
-    needs: build
-    runs-on: ubuntu-latest
-    if: ${{ github.repository == 'mammothbio-os/palamedes' }}
-
-    environment:
-      name: test-release
-      url: https://test.pypi.org/p/palamedes
-
-    permissions:
-      id-token: write
-
-    steps:
-    - name: download build
-      uses: actions/download-artifact@v3
-      with:
-        name: python-package-distributions
-        path: dist/
-
-    - name: publish
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,84 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    if: ${{ github.repository == 'mammothbio-os/palamedes' }}
+    uses: ./.github/workflows/build.yaml
+
+  test-release:
+    name: publish to test pypi
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: test-release
+      url: https://test.pypi.org/p/palamedes
+
+    permissions:
+      id-token: write
+
+    steps:
+    - name: download build
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: publish
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+  release:
+    needs: test-release
+    environment: release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+    - name: download build
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: publish
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  release-github:
+    needs: release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+    - name: download build
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: sign
+      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+
+    - name: create release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: gh release create '${{ github.ref_name }}' --repo '${{ github.repository }}' --notes ""
+
+    - name: upload release artifacts
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: gh release upload '${{ github.ref_name }}' dist/** --repo '${{ github.repository }}'

--- a/palamedes/__init__.py
+++ b/palamedes/__init__.py
@@ -8,7 +8,7 @@ from palamedes.hgvs.utils import categorize_variant_block
 from palamedes.hgvs.builders import BUILDER_CONFIG
 
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 
 
 def generate_hgvs_variants(

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,6 +5,6 @@ pytest-cov~=2.11.1
 pytest~=6.2.1
 ipdb~=0.13.4
 sphinx~=7.2.6
-bumpversion~=0.6.0
 sphinx-rtd-theme~=2.0.0
 myst-parser~=2.0.0
+bump-my-version~=0.19.3

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "0.0.1"
+version = "0.0.2"
 
 setup(
     name="palamedes",


### PR DESCRIPTION
## Description
<!-- please add a summary for this PR. Remember this summary should "scale" with the size of the PR!  -->
A few more tweaks and updates to the PyPI builds. I was hoping that test pypi was a bit more allowing when it came to re-uploading builds, but that is not the case (see last on merge build error). Given that, it is clear we need to isolate all the building and pushing into a single release workflow. I have removed the test publish from the merge workflow and added it to a new "release" workflow that will only run on pushed tags (to the mammoth os org, thanks @heuermh). This also handles creating the github release object and uploading the built files there as well (after signing). This only happens if the test release works, so its still somewhat of a useful test.

I also looked more into `bumpversion` and it is deprecated in favor of `bump-my-version`, so I updated to that and tweaked the configs. I set it up to not create the tag by default while I/we work out a more formal process for how we push the tag that will ultimately trigger this release workflow. I also bumped the version since 0.0.1 is uploaded to test now and any attempt to re-upload it will fail.

## Relevant Links
<!-- please add any relevant links or resources -->
- https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

### Screenshots & Media
<!-- if relevant, add an screenshots, images or recordings -->
<img width="1139" alt="Screen Shot 2024-03-26 at 3 43 56 PM" src="https://github.com/mammothbio-os/palamedes/assets/3450485/e19c27b2-f49b-46cd-bad9-62a2234b7c72">

