### PR TITLE
add rtd config, isolate docs deps

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+   install:
+   - requirements: docs/requirements_docs.txt

--- a/docs/requirements_docs.txt
+++ b/docs/requirements_docs.txt
@@ -1,0 +1,3 @@
+sphinx~=7.2.6
+sphinx-rtd-theme~=2.0.0
+myst-parser~=2.0.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,10 +1,8 @@
 -r requirements.txt
+-r docs/requirements_docs.txt
 ruff~=0.3.3
 mypy~=1.9.0
 pytest-cov~=2.11.1
 pytest~=6.2.1
 ipdb~=0.13.4
-sphinx~=7.2.6
-sphinx-rtd-theme~=2.0.0
-myst-parser~=2.0.0
 bump-my-version~=0.19.3


### PR DESCRIPTION
## Description
<!-- please add a summary for this PR. Remember this summary should "scale" with the size of the PR!  -->
As part of the readthedocs onboarding process, a `.readthedocs.yaml` config file is required at the repo root. It also suggests a separate requirements file for the docs requirements, so I moved all docs pip deps into a new file (and `-r`'ed it into the dev one).


### Screenshots & Media
<!-- if relevant, add an screenshots, images or recordings -->
<img width="948" alt="Screen Shot 2024-03-27 at 9 24 57 AM" src="https://github.com/mammothbio-os/palamedes/assets/3450485/abbe8e06-012e-4038-8847-63121f72bfb1">
<img width="967" alt="Screen Shot 2024-03-27 at 9 25 04 AM" src="https://github.com/mammothbio-os/palamedes/assets/3450485/01cebf9c-3d92-4cef-bc1e-92955ea9cffd">


### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
I manually tested that docs build locally using a clean venv with just the docs requirements. See screenshots.