### PR TITLE
Add pip install local block to rtd config for autofunction to work

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,5 +9,7 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-   install:
-   - requirements: docs/requirements_docs.txt
+  install:
+  - requirements: docs/requirements_docs.txt
+  - method: pip
+    path: .


### PR DESCRIPTION
## Description
<!-- please add a summary for this PR. Remember this summary should "scale" with the size of the PR!  -->
After the last PR I was able to get RTD building and deployed: https://mammothbio-os-palamedes.readthedocs.io/en/latest/#api. However, the API section, which is generated by `autofunction`, is not rendering. This is due to `autofunction` requiring that the referenced package is installed in the env that the doc generation runs in. This PR added the configs to the `.readthedocs.yaml` config to pip install the palamedes package prior to the build.

## Relevant Links
<!-- please add any relevant links or resources -->
https://docs.readthedocs.io/en/stable/config-file/v2.html#packages

### Screenshots & Media
<!-- if relevant, add an screenshots, images or recordings -->
<img width="1151" alt="Screen Shot 2024-03-27 at 11 06 04 AM" src="https://github.com/mammothbio-os/palamedes/assets/3450485/d8dfd429-4fea-4fc4-bd78-32d03759432b">

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
I dont know of a way to test this build locally, so we will just have to merge and see
