### PR TITLE
Docs badges etc

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.2
+current_version = 0.0.3
 commit = True
 tag = False
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # palamedes
 
+![Merge - Passing](https://github.com/mammothbio-os/palamedes/actions/workflows/merge.yaml/badge.svg) ![Release - Passing](https://github.com/mammothbio-os/palamedes/actions/workflows/release.yaml/badge.svg) ![PyPI - Version](https://img.shields.io/pypi/v/palamedes) ![Read The Docs - Version](https://readthedocs.org/projects/mammothbio-os-palamedes/badge/?version=stable)
+
 This repo contains a python package and CLI entrypoint which can be used to generate a list of [HGVS](https://github.com/biocommons/hgvs) variants representing the difference between 2 sequences, using a global alignment. The idea is to leverage the HGVS spec for more applications, since it provides a solid framework for maintaining a consistent set of rules and logic
 around variants.
+
+## Documentation
+
+Documentation for the project can be found [here](https://mammothbio-os-palamedes.readthedocs.io/en/stable/)
 
 ## Installing
 

--- a/palamedes/__init__.py
+++ b/palamedes/__init__.py
@@ -8,7 +8,7 @@ from palamedes.hgvs.utils import categorize_variant_block
 from palamedes.hgvs.builders import BUILDER_CONFIG
 
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 
 
 def generate_hgvs_variants(

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "0.0.2"
+version = "0.0.3"
 
 setup(
     name="palamedes",


### PR DESCRIPTION
## Description
<!-- please add a summary for this PR. Remember this summary should "scale" with the size of the PR!  -->
Hopefully the last PR on the docs front. RTD is all setup, we just need to trigger a new versioned/tagged build to get the "stable" docs page built. I made some updates to the README to include status badges and a link to the docs. Docs currently say failed since it's linked to the `stable` version which has not built since the `v0.0.2` tag. Once I push the tag for this, it should be green.

### Screenshots & Media
<!-- if relevant, add an screenshots, images or recordings -->
![Screen Shot 2024-03-27 at 12 44 47 PM](https://github.com/mammothbio-os/palamedes/assets/3450485/0558290d-fef1-4117-a3b7-d4cdf9644533)
