### PR TITLE
fix performance issue finding last alignment with lots of alignments

### DIFF
--- a/palamedes/align.py
+++ b/palamedes/align.py
@@ -43,7 +43,7 @@ def reverse_seq_record(seq_record: SeqRecord) -> SeqRecord:
     the best alignment.
     """
     return SeqRecord(
-        Seq("".join(reversed(seq_record.seq))),
+        Seq(seq_record.seq[::-1]),
         id=seq_record.id,
         name=seq_record.name,
         description=seq_record.description,

--- a/palamedes/align.py
+++ b/palamedes/align.py
@@ -202,15 +202,15 @@ def generate_alignment(
             reversed_alignment[1][::-1],
         ]
     )
-    foward_alignment = Alignment(
+    forward_alignment = Alignment(
         [reference_seq_record, alternate_seq_record],
         forward_coordinates,
     )
 
     # score is not technically an attribute on the class
-    setattr(foward_alignment, "score", reversed_alignment.score)
+    setattr(forward_alignment, "score", reversed_alignment.score)
 
-    return foward_alignment
+    return forward_alignment
 
 
 def generate_variant_blocks(alignment: Alignment) -> list[VariantBlock]:

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -197,6 +197,57 @@ class GenerateAlignmentTestCase(PalamedesBaseCase):
         alignment = generate_alignment(ref, alt, aligner=custom_aligner)
         self.assertTrue(alignment.score, custom_match_score)
 
+    def test_generate_alignment_three_prime_end_most_del(self):
+        ref, alt = self.make_seq_records(
+            "T" + "A" * 10 + "G",
+            "T" + "A" * 9 + "G",
+        )
+
+        alignment = generate_alignment(ref, alt)
+
+        # ensure we get the ref unchanged
+        # and the last A deleted, not any others
+        self.assertEqual(alignment[0], ref.seq)
+        self.assertEqual(alignment[1], "T" + "A" * 9 + "-G")
+
+    def test_generate_alignment_three_prime_end_most_double_del(self):
+        ref, alt = self.make_seq_records(
+            "ATTGCCA",
+            "ATGCA",
+        )
+
+        alignment = generate_alignment(ref, alt)
+
+        # ensure we get the ref unchanged
+        # and the second of each paired based deleted
+        self.assertEqual(alignment[0], ref.seq)
+        self.assertEqual(alignment[1], "AT-GC-A")
+
+    def test_generate_alignment_three_prime_end_most_ins(self):
+        ref, alt = self.make_seq_records(
+            "T" + "A" * 9 + "G",
+            "T" + "A" * 10 + "G",
+        )
+
+        alignment = generate_alignment(ref, alt)
+
+        # ensure we get the alt unchanged
+        # and the insertion happens after the last A in the ref
+        self.assertEqual(alignment[0], "T" + "A" * 9 + "-G")
+        self.assertEqual(alignment[1], alt.seq)
+
+    def test_generate_alignment_three_prime_end_most_double_ins(self):
+        ref, alt = self.make_seq_records(
+            "ATGCA",
+            "ATTGCCA",
+        )
+        alignment = generate_alignment(ref, alt)
+
+        # ensure we get the alt unchanged
+        # and the insertion happens after the last A in the ref
+        self.assertEqual(alignment[0], "AT-GC-A")
+        self.assertEqual(alignment[1], alt.seq)
+
 
 class GenerateVariantBlocksTestCase(PalamedesBaseCase):
     def test_generate_variant_blocks_all_matches(self):


### PR DESCRIPTION
## Description
<!-- please add a summary for this PR. Remember this summary should "scale" with the size of the PR!  -->
After some extensive testing, I have identified a fairly significant bottleneck in the alignment code for highly divergent sequences which produce a large number of alignments. We attempt to take the last one in the set of alignments, but this is a generate with an expensive next operation, so advancing to the last alignment has the potential to take quite a long time. Additionally, we were doing it in a list comp so the memory usage exploded. As a cherry on top, I misread the docs and all alignments returned are assumed to be tied for score, so doing the check is pointless. We would still need to advance to the end, which is not doable for large alignment sets. We very much want that last alignment in order to follow the 3' end rule for HGVS. To that end, I have updated the code with an idea that I "think" works. I have not fully validated it in all cases but the basic idea is that we:
- Figure out how to "reverse" an alignment (just reference the gapped sequences)
- Reverse the input sequences and generate alignments
- Take the first alignment and then "reverse" it using the logic above

The thinking is that the "first" alignment in the reverse, should correspond to the last alignment in the forward. If we can correctly reverse the alignment, then we can access the last forward alignment in a much more performant manner. A toy example is as follows. Given `ATTG` and `ATG`, we want to gap the second T. We get 2 alignments back from the aligner:
```
> palamedes ATTG ATG
First:
ref               0 ATTG 4
                  0 |-|| 4
alt               0 A-TG 3


Last:
ref               0 ATTG 4
                  0 ||-| 4
alt               0 AT-G 3
```

If we align the reversed sequences:
```
> palamedes GTTA GTA
First:
ref               0 GTTA 4
                  0 |-|| 4
alt               0 G-TA 3


Last:
ref               0 GTTA 4
                  0 ||-| 4
alt               0 GT-A 3
```

If you reverse the first alignment provided by the second call you get:
```
ATTG
||-|
AT-G
```
Which is the second alignment provided by the forward.

I added a few additional test cases to ensure this is working. I would love feedback from folks on edge cases or additional test cases they would like added.

## Relevant Links
<!-- please add any relevant links or resources -->
https://www.sophiagenetics.com/science-hub/hgvs-nomenclature/: The "The 3 prime rule for mutation nomenclature" second

### Screenshots & Media
<!-- if relevant, add an screenshots, images or recordings -->
Random 500 residue AA vs another random one, killed manually after on min on `main`:
<img width="3008" alt="Screen Shot 2024-04-17 at 3 01 04 PM" src="https://github.com/mammothbio-os/palamedes/assets/3450485/d1392a4c-2eb9-43a5-98a6-d5b88bad2e2f">
Finished quickly on new branch:
<img width="2997" alt="Screen Shot 2024-04-17 at 3 28 03 PM" src="https://github.com/mammothbio-os/palamedes/assets/3450485/c02e50c8-86d2-4c6d-ac07-a5a1961f9705">

200 residue test, showing perf improvement and same results:
<img width="2098" alt="Screen Shot 2024-04-17 at 3 30 53 PM" src="https://github.com/mammothbio-os/palamedes/assets/3450485/5f4a7781-73bc-45ad-86ff-cde67c98ad73">
<img width="2133" alt="Screen Shot 2024-04-17 at 3 31 00 PM" src="https://github.com/mammothbio-os/palamedes/assets/3450485/25ceaf91-2ff1-4613-9112-87078e65729a">

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
- As mentioned, added unit tests for some cases. All other tests pass (although there was not much alignment testing happening)
- See screenshot for performance test showing big improvement on highly divergent sequences