### PR TITLE
Flag for multi base subsitutions

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.4
+current_version = 0.0.5
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.5
+current_version = 0.0.6
 commit = True
 tag = False
 

--- a/palamedes/__init__.py
+++ b/palamedes/__init__.py
@@ -8,7 +8,7 @@ from palamedes.hgvs.utils import categorize_variant_block
 from palamedes.hgvs.builders import BUILDER_CONFIG
 
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 
 
 def generate_hgvs_variants(

--- a/palamedes/__init__.py
+++ b/palamedes/__init__.py
@@ -16,6 +16,7 @@ def generate_hgvs_variants(
     alternate_sequence: str | SeqRecord,
     molecule_type: str = MOLECULE_TYPE_PROTEIN,
     aligner: PairwiseAligner | None = None,
+    use_non_standard_substitution_rules: bool = False,
 ) -> list[SequenceVariant]:
     """
     Given the reference and alternate sequences, as either strings or `Bio.SeqRecord.SeqRecord` objects, compute the
@@ -32,6 +33,10 @@ def generate_hgvs_variants(
     - mismatch score: `-1`
     - open gap score: `-1`
     - extend gap score: `-0.1`
+
+    An optional flag: `use_non_standard_substitution_rules` can be passed as `True`, which will enable logic that treats
+    multiple consecutive mismatches as seperare subsitutions, vs merging together into a delins. This is against HGVS
+    spec but has utility for some use cases.
 
     If using pre-built `SeqRecord` objects, be sure to set the `molecule_type` annotation key to a supported molecule type
     and pass in the corresponding molecule_type as an input. At the time of writing, only `protein` is supported as a
@@ -80,7 +85,10 @@ def generate_hgvs_variants(
     )
 
     alignment = generate_alignment(ref_seq_record, alt_seq_record, molecule_type=molecule_type, aligner=aligner)
-    variant_blocks = generate_variant_blocks(alignment)
+    variant_blocks = generate_variant_blocks(
+        alignment,
+        split_consecutive_mismatches=use_non_standard_substitution_rules,
+    )
     builder = BUILDER_CONFIG[molecule_type](alignment)
     return [
         builder.build(

--- a/palamedes/__init__.py
+++ b/palamedes/__init__.py
@@ -8,7 +8,7 @@ from palamedes.hgvs.utils import categorize_variant_block
 from palamedes.hgvs.builders import BUILDER_CONFIG
 
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"
 
 
 def generate_hgvs_variants(

--- a/palamedes/__main__.py
+++ b/palamedes/__main__.py
@@ -1,13 +1,21 @@
 import logging
 from argparse import ArgumentParser
 
+from Bio.Align import PairwiseAligner
+
 from palamedes.align import generate_seq_record, generate_alignment, generate_variant_blocks
 from palamedes.config import MOLECULE_TYPE_PROTEIN, ALT_SEQUENCE_ID, REF_SEQUENCE_ID
-
 from palamedes import __version__
 from palamedes.hgvs.utils import categorize_variant_block
 from palamedes.hgvs.builders import BUILDER_CONFIG
 from palamedes.utils import configure_logging
+from palamedes.config import (
+    GLOBAL_ALIGN_MODE,
+    DEFAULT_MATCH_SCORE,
+    DEFAULT_MISMATCH_SCORE,
+    DEFAULT_OPEN_GAP_SCORE,
+    DEFAULT_EXTEND_GAP_SCORE,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -47,6 +55,39 @@ def main() -> None:
         default=MOLECULE_TYPE_PROTEIN,
     )
     parser.add_argument(
+        "--use-non-standard-substitution-rules",
+        help=(
+            "Flag to enable non-standard substitution rules, "
+            "replacing balanced delins calls with multiple substitutions"
+        ),
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--match-score",
+        help="Match score to use for base alignment",
+        type=int,
+        default=DEFAULT_MATCH_SCORE,
+    )
+    parser.add_argument(
+        "--mismatch-score",
+        help="Mismatch score to use for base alignment",
+        type=int,
+        default=DEFAULT_MISMATCH_SCORE,
+    )
+    parser.add_argument(
+        "--gap-open-score",
+        help="Gap open score to use for base alignment",
+        type=int,
+        default=DEFAULT_OPEN_GAP_SCORE,
+    )
+    parser.add_argument(
+        "--gap-extend-score",
+        help="Gap extend score to use for base alignment",
+        type=int,
+        default=DEFAULT_EXTEND_GAP_SCORE,
+    )
+    parser.add_argument(
         "--debug",
         help="Enable debug logging to stderr",
         action="store_true",
@@ -63,19 +104,38 @@ def main() -> None:
 
     LOGGER.debug("Running with args: %s", args)
 
+    aligner = PairwiseAligner(
+        mode=GLOBAL_ALIGN_MODE,
+        match_score=args.match_score,
+        mismatch_score=args.mismatch_score,
+        open_gap_score=args.gap_open_score,
+        extend_gap_score=args.gap_extend_score,
+    )
+
     ref_seq_record = generate_seq_record(args.ref, args.ref_id, molecule_type=args.molecule_type)
     alt_seq_record = generate_seq_record(args.alt, args.alt_id, molecule_type=args.molecule_type)
-    alignment = generate_alignment(ref_seq_record, alt_seq_record, molecule_type=args.molecule_type)
+    alignment = generate_alignment(
+        ref_seq_record,
+        alt_seq_record,
+        molecule_type=args.molecule_type,
+        aligner=aligner,
+    )
 
     LOGGER.debug("Found best alignment with score = %s", getattr(alignment, "score"))
     LOGGER.debug("Alignment:\n%s", str(alignment))
 
-    variant_blocks = generate_variant_blocks(alignment)
+    variant_blocks = generate_variant_blocks(
+        alignment,
+        split_consecutive_mismatches=args.use_non_standard_substitution_rules,
+    )
     LOGGER.debug("%s Variant blocks generated", len(variant_blocks))
 
     builder = BUILDER_CONFIG[args.molecule_type](alignment)
     for variant_block in variant_blocks:
-        category = categorize_variant_block(variant_block, alignment)
+        category = categorize_variant_block(
+            variant_block,
+            alignment,
+        )
         LOGGER.debug("%s, categorized as: %s", variant_block, category)
 
         hgvs = builder.build(variant_block, category)

--- a/palamedes/align.py
+++ b/palamedes/align.py
@@ -119,17 +119,18 @@ def merge_reduce(
     # base check for merge-ability
     base_can_merge = can_merge_variant_blocks(peek_block, next_block)
 
-    # extra check for flag, merge if false OR merge if true and left and right
+    # extra check for flag, merge if false OR merge if true and one of  left and right
     # are not single bp mismatches. If true and both are single base mismatches
     # then we do not merge, this 'splitting'
-    mismatch_split_can_merge = not split_consecutive_mismatches or all(
+    should_split_mismatches = all(
         [
-            peek_block.alignment_block.bases != VARIANT_BASE_MISMATCH,
-            next_block.alignment_block.bases != VARIANT_BASE_MISMATCH,
+            split_consecutive_mismatches,
+            peek_block.alignment_block.bases == VARIANT_BASE_MISMATCH,
+            next_block.alignment_block.bases == VARIANT_BASE_MISMATCH,
         ]
     )
 
-    if base_can_merge and mismatch_split_can_merge:
+    if base_can_merge and not should_split_mismatches:
         blocks[-1] = merge_variant_blocks(peek_block, next_block)
     else:
         blocks.append(next_block)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "0.0.4"
+version = "0.0.5"
 
 setup(
     name="palamedes",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = "0.0.5"
+version = "0.0.6"
 
 setup(
     name="palamedes",

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -318,3 +318,18 @@ class GenerateVariantBlocksTestCase(PalamedesBaseCase):
         )
         self.assertEqual(variant_blocks[1].reference_blocks, [Block(3, 4, "T")])
         self.assertEqual(variant_blocks[1].alternate_blocks, [Block(2, 5, "GAA")])
+
+    def test_generate_variant_blocks_split_subs(self):
+        alignment = self.make_alignment(
+            "AAAA",
+            "TTTT",
+        )
+        variant_blocks = generate_variant_blocks(alignment, split_consecutive_mismatches=True)
+
+        self.assertEqual(len(variant_blocks), 4)
+        for idx, block in enumerate(variant_blocks):
+            expected_start = idx
+            expecte_end = idx + 1
+            self.assertEqual(block.alignment_block, Block(expected_start, expecte_end, VARIANT_BASE_MISMATCH))
+            self.assertEqual(block.reference_blocks, [Block(expected_start, expecte_end, "A")])
+            self.assertEqual(block.alternate_blocks, [Block(expected_start, expecte_end, "T")])

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -333,3 +333,31 @@ class GenerateVariantBlocksTestCase(PalamedesBaseCase):
             self.assertEqual(block.alignment_block, Block(expected_start, expecte_end, VARIANT_BASE_MISMATCH))
             self.assertEqual(block.reference_blocks, [Block(expected_start, expecte_end, "A")])
             self.assertEqual(block.alternate_blocks, [Block(expected_start, expecte_end, "T")])
+
+    def test_generate_variant_blocks_no_split_indels(self):
+        """Test split flag does not change how actual indels are treated"""
+        alignment = self.make_alignment(
+            "AAAA---",
+            "---TTTT",
+        )
+        variant_blocks = generate_variant_blocks(alignment, split_consecutive_mismatches=True)
+        self.assertEqual(len(variant_blocks), 1)
+
+        self.assertEqual(
+            variant_blocks[0].alignment_block,
+            Block(
+                0,
+                7,
+                "".join(
+                    [
+                        VARIANT_BASE_DELETION,
+                        VARIANT_BASE_DELETION,
+                        VARIANT_BASE_DELETION,
+                        VARIANT_BASE_MISMATCH,
+                        VARIANT_BASE_INSERTION,
+                        VARIANT_BASE_INSERTION,
+                        VARIANT_BASE_INSERTION,
+                    ]
+                ),
+            ),
+        )


### PR DESCRIPTION
## Description
<!-- please add a summary for this PR. Remember this summary should "scale" with the size of the PR!  -->
It has been determined that for certain use cases, it may be desirable to treat a sequence of mismatches independently, vs collapsing them into a `delins`. This is especially the case when the `delins` would be "balanced", in other words 3 deleted --> 3 inserted. This goes against the HGVS spec, so I have added it as an explicit opt-in flag. Note that with the default params, it is unlikely to get a raw alignment that looks like this (since opening a gap is cheaper). In almost all cases, custom alignment params would be required to trigger this case (and the flag needs to be passed). To simplify testing of this, I also added the ability to configure alignment params from the CLI.

## Relevant Links
<!-- please add any relevant links or resources -->
N/A

### Screenshots & Media
<!-- if relevant, add an screenshots, images or recordings -->
Base alignment:
<img width="1789" alt="Screen Shot 2024-06-12 at 2 08 32 PM" src="https://github.com/mammothbio-os/palamedes/assets/3450485/bd47ee5c-fdf6-4d25-a9a4-38536593b7c4">

With flag but no params:
<img width="1792" alt="Screen Shot 2024-06-12 at 2 08 53 PM" src="https://github.com/mammothbio-os/palamedes/assets/3450485/4f680893-67ba-42bb-adda-de2f18a2685f">

With flag and mismatch bias params:
<img width="1787" alt="Screen Shot 2024-06-12 at 2 09 09 PM" src="https://github.com/mammothbio-os/palamedes/assets/3450485/7732998c-cd76-47e6-8b6d-908d42676375">


### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
- Unit test added
- Tested toy example through CLI, see images

### Code Flow
<!-- if relevant, document the flow of the logic/data/code -->
N/A

### Edge cases / Breaking Changes / Known Issues
<!-- if relevant, document any edge cases, known issues, etc -->
N/A
